### PR TITLE
Fix numpy error by changing empty transpose() to T

### DIFF
--- a/src/cdtools/tools/initializers/initializers.py
+++ b/src/cdtools/tools/initializers/initializers.py
@@ -57,7 +57,7 @@ def exit_wave_geometry(det_basis, det_shape, wavelength, distance, oversampling=
 
     # This method should work for a general parallelogram-shaped detector
     det_shape = det_basis * det_shape.to(t.float32)
-    pinv_basis = t.tensor(np.linalg.pinv(det_shape).transpose()).to(t.float32)
+    pinv_basis = t.tensor(np.linalg.pinv(det_shape).T).to(t.float32)
     real_space_basis = pinv_basis * wavelength * distance
 
     return real_space_basis


### PR DESCRIPTION
There is an "empty" `ndarray.transpose()` in `initializers.py` leading to an error in `cdtools.datasets.Ptycho2DDataset.from_cxi`. 

Change `.transpose()` to `.T` to fix it. 

---

Repro (`examples/fancy_ptycho.py`):

```python
import cdtools
from matplotlib import pyplot as plt

filename = 'example_data/lab_ptycho_data.cxi'
dataset = cdtools.datasets.Ptycho2DDataset.from_cxi(filename)
```

gives 

```
File /das/work/units/csaxs/p21610/git/cdtools/src/cdtools/tools/initializers/initializers.py:60, in exit_wave_geometry(det_basis, det_shape, wavelength, distance, oversampling)              
     56 # Generate the basis for the exit wave in real space
     57
     58 # This method should work for a general parallelogram-shaped detector
     59 det_shape = det_basis * det_shape.to(t.float32)
---> 60 pinv_basis = t.tensor(np.linalg.pinv(det_shape).transpose()).to(t.float32)
     61 real_space_basis = pinv_basis * wavelength * distance
     63 return real_space_basis

TypeError: transpose() received an invalid combination of arguments - got (), but expected one of:                                                                                            
 * (int dim0, int dim1)
 * (name dim0, name dim1)
```