### PR TITLE
Fixing oversampling in Bragg2DPtycho

### DIFF
--- a/src/cdtools/models/bragg_2d_ptycho.py
+++ b/src/cdtools/models/bragg_2d_ptycho.py
@@ -371,11 +371,17 @@ class Bragg2DPtycho(CDIModel):
 
         obj = t.exp(1j*(randomize_ang * (t.rand(obj_size)-0.5)))
 
-        pfc = (probe_fourier_crop if probe_fourier_crop else 0)
+        pfc = (probe_fourier_crop if probe_fourier_crop else [0,0])
         if obj_view_crop is None:
-            obj_view_crop = min(probe.shape[-2], probe.shape[-1]) // 2 + pfc
+            obj_view_crop = min(
+                probe.shape[-2] // 2 + pfc[0],
+                probe.shape[-1] // 2 + pfc[1]
+            )
         if obj_view_crop < 0:
-            obj_view_crop += min(probe.shape[-2], probe.shape[-1]) // 2 + pfc
+            obj_view_crop += min(
+                probe.shape[-2] // 2 + pfc[0],
+                probe.shape[-1] // 2 + pfc[1]
+            )
 
         obj_view_crop += obj_padding
         

--- a/src/cdtools/models/fancy_ptycho.py
+++ b/src/cdtools/models/fancy_ptycho.py
@@ -103,9 +103,16 @@ class FancyPtycho(CDIModel):
         self.probe = t.nn.Parameter(probe_guess / self.probe_norm)
         self.obj = t.nn.Parameter(obj_guess)
 
-
-        self.obj_view_slice = np.s_[obj_view_crop:-obj_view_crop,
-                                    obj_view_crop:-obj_view_crop]
+        # NOTE: I think it makes sense to protect against obj_view_crop
+        # being zero or below, because there is nothing else to show outside
+        # the object array. No reason to throw an error if, e.g., the user
+        # asks for a big padding which goes outside of the actual object array.
+        # Just show the full array.
+        if obj_view_crop > 0:
+            self.obj_view_slice = np.s_[obj_view_crop:-obj_view_crop,
+                                        obj_view_crop:-obj_view_crop]
+        else:
+            self.obj_view_slice = np.s_[:,:]
         
         # TODO: perhaps not working anymore for fourier cropped probes
         if background is None:

--- a/src/cdtools/models/fancy_ptycho.py
+++ b/src/cdtools/models/fancy_ptycho.py
@@ -505,6 +505,7 @@ class FancyPtycho(CDIModel):
             shift_probe=True,
             multiple_modes=True,
             probe_support=self.probe_support)
+        
         return exit_waves
 
 
@@ -522,7 +523,7 @@ class FancyPtycho(CDIModel):
             self.background,
             measurement=tools.measurements.incoherent_sum,
             saturation=self.saturation,
-            oversampling=int(self.oversampling),
+            oversampling=self.oversampling,
             simulate_finite_pixels=self.simulate_finite_pixels,
         )
 


### PR DESCRIPTION
There was an issue with the oversampling parameter in the Bragg2DPtycho model when correct_tilt=True. This should fix it, plus I moved over the object_view_crop stuff from FancyPtycho because it was so useful.