### PR TITLE
Add a function to shrink the range of translation positions in a dataset

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,6 +6,7 @@ import h5py
 import datetime
 from copy import deepcopy
 import pytest
+import itertools
 
 #
 # We start by testing the CDataset base class
@@ -341,7 +342,7 @@ def test_Ptycho2DDataset_downsample(test_ptycho_cxis):
                                    np.array(copied_dataset.background.shape))
         
 
-def test_Ptycho2DDataset_crop_2D_translations(ptycho_cxi_1):
+def test_Ptycho2DDataset_crop_translations(ptycho_cxi_1):
     # Grab dataset
     cxi, expected = ptycho_cxi_1
     dataset = Ptycho2DDataset.from_cxi(cxi)
@@ -353,42 +354,59 @@ def test_Ptycho2DDataset_crop_2D_translations(ptycho_cxi_1):
     #   (it looks like a line scan). We select an ROI at (0, -300) which should 
     #   not contain any translation positions.
     with pytest.raises(ValueError) as excinfo:
-        copied_dataset.crop_2D_translations(roi=(0,-5,-295,-300))
+        copied_dataset.crop_translations(roi=(0,-5,-295,-300))
     assert('(i.e., patterns and translations will be empty)') in str(excinfo.value)
 
-    # Test 2: Draw an ROI that's centered in the middle of the x/y translation range,
-    #   but complain because the bounds of the ROI are incorrectly defined
+    # Test 2: Draw an ROI that's centered in the middle of the x/y translation range
+    #   and make sure that the first and last x/y elements in dataset.translate
+    #   contain x_left, x_right, y_top, and y_bottom
+
+    #   Make tuples that will store the x and y positions. This will be used for
+    #   making permutations of the x/y positions in the ROI later.
     x_left, y_top = dataset.translations[10,:2]
     x_right, y_bottom = dataset.translations[-11,:2]
 
-    with pytest.raises(ValueError) as excinfo:
-        copied_dataset.crop_2D_translations(roi=(x_right,x_left,y_bottom,y_top))
-    assert('(i.e., patterns and translations will be empty)') in str(excinfo.value)
+    x_permutations = ((x_left, x_right), (x_right, x_left))
+    y_permutations = ((y_top, y_bottom), (y_bottom, y_top))
+    roi_permutations = tuple((x1, x2, y1, y2) for (x1, x2), (y1, y2) in
+                              itertools.product(x_permutations, y_permutations))
 
-    # Test 3: Basically Test 2, but don't complain when the bounds are set correctly
-    copied_dataset.crop_2D_translations(roi=(x_left,x_right,y_top,y_bottom))
+    #   Get the dataset
+    copied_dataset.crop_translations(roi=roi_permutations[0])
 
-    # Test 4: Make sure that the first and last x/y elements in dataset.translate
-    #   match x_left, x_right, y_top, and y_bottom
-    assert t.allclose(t.tensor([x_left, y_top]), copied_dataset.translations[0,:2])
+    #   Execute the actual test
+    assert (copied_dataset.translations[0,0] in x_permutations[0]) and \
+        (copied_dataset.translations[-1,0] in x_permutations[0])
+    
+    assert (copied_dataset.translations[0,1] in y_permutations[0]) and \
+        (copied_dataset.translations[-1,1] in y_permutations[0])
 
-    assert t.allclose(t.tensor([x_right, y_bottom]), copied_dataset.translations[-1,:2])
-
-    # Test 5: Check if the shape of dataset.patterns and dataset.translate is correct
+    # Test 3: Check if the shape of dataset.patterns and dataset.translate is correct
     #   (designed to be 20 fewer rows here)
+    #   In the future, this should include a check for dataset.intensities once
+    #   an appropriate cxi file is set up for conftest.
     expected_patterns_shape = np.concatenate([[dataset.patterns.shape[0] - 20], 
-                                             dataset.patterns.shape[-2:]])
+                                            dataset.patterns.shape[-2:]])
     
     expected_translations_shape = np.concatenate([[dataset.translations.shape[0] - 20], 
-                                                 dataset.translations.shape[-1:]])
+                                                dataset.translations.shape[-1:]])
 
-    assert np.allclose(np.array(copied_dataset.patterns.shape),
-                       expected_patterns_shape)
-    
-    assert np.allclose(np.array(copied_dataset.translations.shape),
-                       expected_translations_shape)
-    
-    # Test 6: Check if the contents of dataset.patterns and dataset.translate is correct
-    assert t.allclose(copied_dataset.patterns, dataset.patterns[10:-10,:])
+    assert np.allclose(np.array(copied_dataset.patterns.shape), expected_patterns_shape)
+        
+    assert np.allclose(np.array(copied_dataset.translations.shape), expected_translations_shape)
 
-    assert t.allclose(copied_dataset.translations, dataset.translations[10:-10,:])
+    # Test 4: Make sure that we always get the same result no matter what order we
+    #   define the left/right and bottom/top values in roi, provided that roi[:2] 
+    #   and roi[2:] correspond with the x and y coordinates, respectively.
+
+    #   Check each permutation
+    for roi in roi_permutations:
+        # Copy the dataset again; dataset will be modified each time crop_translation
+        # is successfully executed.
+        copied_dataset = deepcopy(dataset)
+        copied_dataset.crop_translations(roi=roi)
+
+        # Check if the contents of dataset.patterns and dataset.translate is correct
+        assert t.allclose(copied_dataset.patterns, dataset.patterns[10:-10,:])
+
+        assert t.allclose(copied_dataset.translations, dataset.translations[10:-10,:])


### PR DESCRIPTION
Adding a method crop_2D_translations to Ptycho2DDataset, along with a corresponding test. This method removes from the dataset all translations and corresponding diffraction patterns which lie outside of a rectangular region of interest (ROI). The ROI is defined on the area scanned in a ptychography experiment. In essence, this operation crops the "relative displacement map" (shown in self.inspect()) down to the region of interest.