### PR TITLE
Feature/multi gpu

### DIFF
--- a/examples/fancy_ptycho_multi_gpu_ddp.py
+++ b/examples/fancy_ptycho_multi_gpu_ddp.py
@@ -1,0 +1,44 @@
+import cdtools
+from matplotlib import pyplot as plt
+
+filename = 'example_data/lab_ptycho_data.cxi'
+dataset = cdtools.datasets.Ptycho2DDataset.from_cxi(filename)
+
+# FancyPtycho is the workhorse model
+model = cdtools.models.FancyPtycho.from_dataset(
+    dataset,
+    n_modes=3, # Use 3 incoherently mixing probe modes
+    oversampling=2, # Simulate the probe on a 2xlarger real-space array
+    probe_support_radius=120, # Force the probe to 0 outside a radius of 120 pix
+    propagation_distance=5e-3, # Propagate the initial probe guess by 5 mm
+    units='mm', # Set the units for the live plots
+    obj_view_crop=-50, # Expands the field of view in the object plot by 50 pix
+)
+
+device = 'cuda'
+model.to(device=device)
+dataset.get_as(device=device)
+
+# The learning rate parameter sets the alpha for Adam.
+# The beta parameters are (0.9, 0.999) by default
+# The batch size sets the minibatch size
+for loss in model.Adam_optimize(50, dataset, lr=0.02, batch_size=10):
+    print(model.report())
+    # Plotting is expensive, so we only do it every tenth epoch
+    if model.epoch % 10 == 0:
+        model.inspect(dataset)
+
+# It's common to chain several different reconstruction loops. Here, we
+# started with an aggressive refinement to find the probe, and now we
+# polish the reconstruction with a lower learning rate and larger minibatch
+for loss in model.Adam_optimize(50, dataset,  lr=0.005, batch_size=50):
+    print(model.report())
+    if model.epoch % 10 == 0:
+        model.inspect(dataset)
+
+# This orthogonalizes the recovered probe modes
+model.tidy_probes()
+
+model.inspect(dataset)
+model.compare(dataset)
+plt.show()

--- a/examples/fancy_ptycho_multi_gpu_ddp.py
+++ b/examples/fancy_ptycho_multi_gpu_ddp.py
@@ -1,44 +1,131 @@
 import cdtools
 from matplotlib import pyplot as plt
 
-filename = 'example_data/lab_ptycho_data.cxi'
-dataset = cdtools.datasets.Ptycho2DDataset.from_cxi(filename)
+# To use multiple GPUs, we need to import a few additional packages
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed import init_process_group, destroy_process_group, barrier
+import torch.multiprocessing as mp
 
-# FancyPtycho is the workhorse model
-model = cdtools.models.FancyPtycho.from_dataset(
-    dataset,
-    n_modes=3, # Use 3 incoherently mixing probe modes
-    oversampling=2, # Simulate the probe on a 2xlarger real-space array
-    probe_support_radius=120, # Force the probe to 0 outside a radius of 120 pix
-    propagation_distance=5e-3, # Propagate the initial probe guess by 5 mm
-    units='mm', # Set the units for the live plots
-    obj_view_crop=-50, # Expands the field of view in the object plot by 50 pix
-)
+# While not strictly necessary, it's super useful to have in the event
+# the computation hangs by defining a timeout period. 
+import datetime 
+timeout = datetime.timedelta(seconds=60)   # Terminate if things hang for 60s.
 
-device = 'cuda'
-model.to(device=device)
-dataset.get_as(device=device)
+# We will need to specify what multiprocessing backend we want to use.
+# PyTorch supports a few backends (gloo, MPI, NCCL). We will use NCCL, or
+# NVIDIA Collective Communications Library, as it's the fastest one.
+#
+# It's also the only one that works with the current multi-GPU implementation...
+BACKEND = 'nccl'
 
-# The learning rate parameter sets the alpha for Adam.
-# The beta parameters are (0.9, 0.999) by default
-# The batch size sets the minibatch size
-for loss in model.Adam_optimize(50, dataset, lr=0.02, batch_size=10):
-    print(model.report())
-    # Plotting is expensive, so we only do it every tenth epoch
-    if model.epoch % 10 == 0:
-        model.inspect(dataset)
+# We need to wrap the script inside a function in order to use "mp.spawn"
+# which will help distribute the work to multiple GPUs
+#
+# In fancier terms, we will use mp.spawn to create several processes
+# that will work on the model using N-number of GPUs, (a.k.a., 'WORLD_SIZE')
+# Each process will be given to one GPU that's assigned a number called 
+# a RANK (which ranges from 0 to WORLD_SIZE-1).
+def multi_gpu_reconstruct(rank: int, 
+                          world_size: int):
+    """Perform the reconstruction using several GPUs
+    Parameters:
+        rank: int
+            The rank of the GPU to be used. Value should be within
+            [0, world_size-1]
 
-# It's common to chain several different reconstruction loops. Here, we
-# started with an aggressive refinement to find the probe, and now we
-# polish the reconstruction with a lower learning rate and larger minibatch
-for loss in model.Adam_optimize(50, dataset,  lr=0.005, batch_size=50):
-    print(model.report())
-    if model.epoch % 10 == 0:
-        model.inspect(dataset)
+        world_size: int
+            The total number of GPUs to use
+    """
+    # We need to initialize the distributed process group
+    # before calling any other method
+    init_process_group(backend=BACKEND,
+                       rank=rank,
+                       world_size=world_size,
+                       timeout=timeout)
+    
+    filename = 'example_data/lab_ptycho_data.cxi'
+    dataset = cdtools.datasets.Ptycho2DDataset.from_cxi(filename)
 
-# This orthogonalizes the recovered probe modes
-model.tidy_probes()
+    model = cdtools.models.FancyPtycho.from_dataset(
+        dataset,
+        n_modes=3,
+        oversampling=2, 
+        probe_support_radius=120, 
+        propagation_distance=5e-3,
+        units='mm', 
+        obj_view_crop=-50,
+    )
 
-model.inspect(dataset)
-model.compare(dataset)
-plt.show()
+    # We need to adjust the device string to also indicate which GPU this
+    # process is using
+    device = f'cuda:{rank}'
+    model.to(device=device)
+    dataset.get_as(device=device)
+
+    # We now wrap the model with DistributedDataParallel (DDP), which allows
+    # data parallelism by synchronizing gradients across each copy of the
+    # model in the different GPUs.
+    model = DDP(model,
+                device_ids=[rank],  # Tells DDP which GPU the model lives in
+                output_device=rank, # Tells DDP which GPU to output to
+                find_unused_parameters=True) # TODO: Understand what this is really doing...
+
+    # As a sanity check, we wait for all GPUs to catch up to barrier() before
+    # running optimization
+    barrier()
+    
+
+    # Since our model is now wrapped in DDP, all CDTools methods have to be
+    # called using 'model.module' rather than just 'model'.
+    #
+    # We also need to pass the rank and world_size to Adam_optimize
+    for loss in model.module.Adam_optimize(50, 
+                                           dataset, 
+                                           lr=0.02, 
+                                           batch_size=10,
+                                           rank=rank,
+                                           num_workers=world_size):
+        
+        # We can still perform model.inspect and model.report, but we want
+        # to only let 1 GPU handle plotting/printing rather than get N copies
+        # from all N GPUs.
+        if rank == 0:
+            print(model.module.report())
+        
+        # We set up the model.inspect this way to only let GPU 0 plot and
+        # prevent the other GPUs from running far ahead of GPU 0, which
+        # seems to cause bugs (GPU processes dissapear from nvidia-smi)
+        if model.module..epoch % 10 == 0:
+            if rank == 0:
+                model.module.inspect(dataset)
+            barrier()
+
+
+    # We set up another barrier to make sure all GPUs catch up before
+    # starting another reconstruction loop
+    barrier()
+
+    for loss in model.module.Adam_optimize(50, 
+                                           dataset,  
+                                           lr=0.005, 
+                                           batch_size=50,
+                                           rank=rank,
+                                           num_workers=world_size):
+        if rank == 0:
+            print(model.module.report())
+        
+        if model.epoch % 10 == 0:
+            if rank == 0:
+                model.module.inspect(dataset)
+            barrier()
+
+    # Again, set up another barrier to let all GPUs catch up
+    barrier()
+    
+    model.module.tidy_probes() # TODO: Check how the multi-GPU implementation handles tidying probes.
+
+    # Only let one GPU handle plotting stuff.
+    if rank == 0:
+        model.module.inspect(dataset)
+        model.module.compare(dataset)
+        plt.show()

--- a/examples/fancy_ptycho_multi_gpu_ddp.py
+++ b/examples/fancy_ptycho_multi_gpu_ddp.py
@@ -96,7 +96,7 @@ def multi_gpu_reconstruct(rank: int,
         # We set up the model.inspect this way to only let GPU 0 plot and
         # prevent the other GPUs from running far ahead of GPU 0, which
         # seems to cause bugs (GPU processes dissapear from nvidia-smi)
-        if model.module..epoch % 10 == 0:
+        if model.module.epoch % 10 == 0:
             if rank == 0:
                 model.module.inspect(dataset)
             barrier()

--- a/examples/fancy_ptycho_multi_gpu_ddp_speed_test.py
+++ b/examples/fancy_ptycho_multi_gpu_ddp_speed_test.py
@@ -1,0 +1,215 @@
+'''This is a testing script to study how the reconstruction speed
+and convergence rate scales with the number of GPUs utilized.
+
+The test is set up so that you can run n-trials for each number of GPUs
+you want to study and plot statistics of loss-versus-time as a function
+of GPU counts. 
+
+This test is based on fancy_ptycho_multi_gpu_ddp.py and fancy_ptycho.py.
+
+'''
+
+import cdtools
+from matplotlib import pyplot as plt
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed import init_process_group, destroy_process_group, barrier
+import torch.multiprocessing as mp
+import os
+import datetime 
+import time
+import numpy as np
+
+TIMEOUT = datetime.timedelta(seconds=10)   # Auto-terminate if things hang
+BACKEND = 'nccl'
+
+
+# Multi-GPU supported reconstruction
+def multi_gpu_reconstruct(rank: int, 
+                          world_size: int,
+                          conn,
+                          schedule=False) -> tuple[np.array, np.array]:
+    """Perform the reconstruction using several GPUs
+    If only one GPU is used, we don't bother loading the the process group
+    or doing any of the fancy stuff associated with multi-GPU operation.
+
+    Parameters:
+        rank: int
+            The rank of the GPU to be used. Value should be within
+            [0, world_size-1]
+        world_size: int
+            The total number of GPUs to use
+        conn: mp.Pipe
+            Connection to parent
+        schedule: bool
+            Toggles the use of the scheduler
+    
+    Returns:
+        time_history: np.array
+            Array of when each loss was measured
+        loss_history: np.array
+            The total history of the model
+    """
+    # Create a list to keep track of when each module report was printed
+    t_list = []
+    # Start counting time
+    t_start = time.time()
+
+    # Load the dataset
+    filename = r'example_data/lab_ptycho_data.cxi'
+    dataset = cdtools.datasets.Ptycho2DDataset.from_cxi(filename)
+
+    if world_size > 1:
+        # We need to initialize the distributed process group
+        # before calling any other method for multi-GPU usage
+        init_process_group(backend=BACKEND,
+                        rank=rank,
+                        world_size=world_size,
+                        timeout=TIMEOUT)
+    
+    # Create the model
+    model = cdtools.models.FancyPtycho.from_dataset(
+        dataset,
+        n_modes=3,
+        oversampling=2, 
+        probe_support_radius=120, 
+        propagation_distance=5e-3,
+        units='mm', 
+        obj_view_crop=-50,
+    )
+
+    # Assign devices
+    device = f'cuda:{rank}'
+    model.to(device=device)
+    dataset.get_as(device=device)
+
+    # Perform reconstructions on either single or multi-GPU workflows.
+    if world_size > 1:
+        # For multi-GPU workflows, we have to use this mess.
+        model = DDP(model,
+                    device_ids=[rank],  # Tells DDP which GPU the model lives in
+                    output_device=rank, # Tells DDP which GPU to output to
+                    find_unused_parameters=True) # TODO: Understand what this is really doing...
+        barrier()
+
+        for loss in model.module.Adam_optimize(50, 
+                                            dataset, 
+                                            lr=0.02, 
+                                            batch_size=10,
+                                            rank=rank,
+                                            num_workers=world_size,
+                                            schedule=schedule):
+            if rank == 0:
+                print(model.module.report())
+                t_list.append(time.time() - t_start)
+        barrier()
+
+        for loss in model.module.Adam_optimize(50, 
+                                            dataset,  
+                                            lr=0.005, 
+                                            batch_size=50,
+                                            rank=rank,
+                                            num_workers=world_size,
+                                            schedule=schedule):
+            if rank == 0:
+                print(model.module.report())
+                t_list.append(time.time() - t_start)
+        # Again, set up another barrier to let all GPUs catch up
+        barrier()
+        # Always destroy the process group when you're done
+        destroy_process_group()
+
+        # We need to send the time_history and loss_history through
+        # the child connection to the parent (sitting in the name-main block)
+        if rank == 0:
+            loss_history = np.array(model.module.loss_history)
+            time_history = np.array(t_list)
+            conn.send((time_history, loss_history))
+
+    else:
+        # For single-GPU workloads, we use the vanilla-way of performing
+        # reconstructions in CDTools
+        for loss in model.Adam_optimize(50, dataset, lr=0.02, batch_size=10, schedule=schedule):
+            print(model.report())
+            t_list.append(time.time() - t_start)
+        for loss in model.Adam_optimize(50, dataset,  lr=0.005, batch_size=50, schedule=schedule):
+            print(model.report())
+            t_list.append(time.time() - t_start)
+
+        loss_history = np.array(model.loss_history)
+        time_history = np.array(t_list)
+        # Return the measured time and loss history
+        return time_history, loss_history
+
+# This will execute the multi_gpu_reconstruct upon running this file
+if __name__ == '__main__':
+    # We need to add some stuff to the enviromnent 
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '8888'  # You can use any open port number
+
+    # Set up a parent/child connection to get some info from the GPU-accelerated
+    # function
+    parent_conn, child_conn = mp.Pipe()
+
+    # Define the number of GPUs to use.
+    world_sizes = [2, 1] 
+
+    # Define if we want to use the scheduler or not
+    schedule=True
+
+    # Define how many iterations we want to perform of the reconstructions
+    # for statistics
+    runs = 2
+
+    # Write a try/except statement to help the subprocesses (and GPUs)
+    # terminate gracefully. Otherwise, you may have stuff loaded on
+    # several GPU even after terminating.
+    try:
+        for world_size in world_sizes:
+            print(f'Number of GPU(s): {world_size}')
+            # Make a list to store the values
+            time_list = []
+            loss_hist_list = []
+
+            for i in range(runs):
+                print(f'Starting run {i+1}/{runs} on {world_size} GPU(s)')
+                if world_size == 1:
+                    final_time, loss_history = multi_gpu_reconstruct(0, world_size,schedule)
+                    time_list.append(final_time)
+                    loss_hist_list.append(loss_history)
+                else:
+                    # Spawn the processes
+                    mp.spawn(multi_gpu_reconstruct,
+                             args=(world_size, child_conn, schedule),
+                             nprocs=world_size,
+                             join=True)
+                    while parent_conn.poll():
+                        final_time, loss_history = parent_conn.recv()
+                        time_list.append(final_time)
+                        loss_hist_list.append(loss_history)
+                
+            
+            # Calculate the statistics
+            time_mean = np.array(time_list).mean(axis=0)/60
+            time_std = np.array(time_list).std(axis=0)/60
+            loss_mean = np.array(loss_hist_list).mean(axis=0)
+            loss_std = np.array(loss_hist_list).std(axis=0)
+
+            # Plot
+            plt.errorbar(time_mean, loss_mean, yerr=loss_std, xerr=time_std,
+                     label=f'{world_size} GPUs')
+            plt.yscale('log')
+            plt.xscale('linear')
+        
+        plt.legend()
+        plt.xlabel('Time (min)')
+        plt.ylabel('Loss')
+        plt.show()
+
+
+    except KeyboardInterrupt as e:
+        # If something breaks, we try to make sure that the
+        # process group is destroyed before the program fully
+        # terminates
+        print('Hang on a sec...')
+        destroy_process_group()
+    

--- a/src/cdtools/models/base.py
+++ b/src/cdtools/models/base.py
@@ -30,6 +30,8 @@ loss
 
 import torch as t
 from torch.utils import data as torchdata
+from torch.utils.data.distributed import DistributedSampler
+from torch.nn.parallel import DistributedDataParallel
 from matplotlib import pyplot as plt
 from matplotlib.widgets import Slider
 from matplotlib import ticker


### PR DESCRIPTION
This PR is a starting point to address Issue https://github.com/cdtools-developers/cdtools/issues/8: adding multi-GPU support for CDTools. 

This is a work-in-progress. I'm interested in exploring a couple different parallelization approaches while trying to preserve the simplicity of the high-level CDTools interface and ensure backwards-compatability. 

If you have any recommendations on things to try/test, I'd be happy to discuss it!

## Multi-GPU implementation based on DistributedDataParallel
I've gotten one naive implementation of multi-GPU support operational using PyTorch DistributedDataParallel to perform data parallelism (more details here https://pytorch.org/tutorials/beginner/dist_overview.html):
- 2ad6db2dd6fc47a9e9489bf6d69811cc35655cca, ad3d8166dd33cb3d9144a836d46f70c9f50dd732: Made some changes to the base CDIModel to change how the DataLoader is set up and sampled if multiple GPUs are used. 
- c393f47bd4b747a295d8f6464f686cc758093e5d, fc40b77043b96e068122507ea40aa0e3c0331f8f, e8ed0100c60ce34089f78e8bbd213f96230753b6, 94dcc3fedd7a47bd1f071606bad9ef4b37fd27d3, efe2ac1429236489d071939fe15b40cd79071dea: Created a multi-GPU version of the `examples/fancy_ptycho.py` called `examples/fancy_ptycho_multi_gpu_ddp.py`. The dataset and model inspection methods work even when using multiple GPUs.
- 1eb870465ce063e3f89ec71928bd5ae9106b4f9a: Created `examples/fancy_ptycho_multi_gpu_ddp_speed_test.py` to perform a comparative test of the reconstruction speed/loss as a function of the number of GPUs used. This is based on `examples/fancy_ptycho.py` and `examples/fancy_ptycho_multi_gpu_ddp.py`

Below is an output from `examples/fancy_ptycho_multi_gpu_ddp_speed_test.py` tested using up to 2 NVIDIA RTX 6000 Ada Generation cards on a Linux server. Both a single- and double-GPU test were ran with 2 trials over 100 total epochs. The plots show the mean and standard deviation of the time each epoch was measured at (timer started before the dataset was loaded) as well as the associated loss at each epoch. The horizontal shift between the two plots likely reflect the longer time it takes to load the model to multiple GPUs. The width of the 2 GPU curve (i.e., the total time taken for reconstruction) is roughly half that of the 1 GPU curve.
![Pasted image 20250223213358](https://github.com/user-attachments/assets/a265d121-57e1-4ea9-b3ec-9bc5efff256e)

## Items to look into
- [ ] Look into why the losses become less stable as GPU counts increases
- [ ] Make sure that the batching scheme is behaving as expected as GPU counts increases
- [ ] Avoid changing the high-level interface of CDTools
- [ ] Add PyTests
- [ ] Enable multi-GPU functionality through [Hugging Face Accelerator](https://github.com/huggingface/accelerate)
- [ ] Try out PyTorch [FullyShardedDataParallel](https://pytorch.org/docs/stable/fsdp.html) to distribute the model over several GPUs (in the case the model can't fit on a single GPU)

## Diagnosing issues
I've had issues with running parallelized PyTorch scripts which may not be caused by PyTorch itself, but rather stems from communication issues between NVIDIA GPUs via the NCCL (NVIDIA Collective Communications Library) backend. These issues seem to strongly depend on the exact details of how the machine is set up. To see if there's an issue with NCCL, build and run the following test from https://github.com/NVIDIA/cuda-samples: 
- `cuda-samples/Samples/0_Introduction/simpleP2P` and/or
- `cuda-samples/Samples/5_Domain_Specific/p2pBandwidthLatencyTest` (per the [NCCL troubleshooting guide](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/troubleshooting.html))

If this test fails, or hangs for several minutes, you may have a GPU-GPU communication issue. 

Another symptom of communication-related hanging is if all activated GPUs report 100% usage on `nvidia-smi` and nothing seems to be happening.

I've included some websites below which may be helpful for solving your issues. 
- Disable IOMMU and ACS per the [NCCL troubleshooting guide](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/troubleshooting.html)
- https://forums.developer.nvidia.com/t/p2p-communication-fails-1080ti-1080ti-iommu-acs-disabled/112079