### PR TITLE
Include docs in main repo and automatic deploy using github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,61 @@ jobs:
 
       - name: Run tests
         run: pytest
+
+  build-docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install sphinx sphinx_rtd_theme sphinx-argparse
+          pip install -e . --no-deps
+
+      - name: Build docs
+        working-directory: docs
+        run: |
+          make html
+
+      - name: List files in docs/build/html
+        run: |
+          ls -la docs/build/html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/build/html'
+          name: github-pages
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 600000
+          error_count: 10
+          reporting_interval: 5000
+          artifact_name: github-pages
+          preview: false

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/*
 dist
 */example_data/*
 *.h5
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.egg-info
 .pytest_cache
 docs/build
+docs/_build
 build/*
 dist
 */example_data/*

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,7 +8,7 @@ The source code for CDTools is hosted on `Github`_. At the moment, the repositor
 
 .. _`Github`: https://github.com/cdtools-developers/cdtools
 
-The repository remains under active development as of late 2024.
+The repository remains under active development as of early 2025.
 
 Step 2: Install Dependencies
 ----------------------------


### PR DESCRIPTION
This PR will create the docs for every update in the `master` branch, as it was discussed as an option in #20. I tested it in the `master` branch of my fork (https://github.com/gnzng/cdtools/actions/runs/13619770916). The build from docs from the workflow can be found here: https://gnzng.github.io/cdtools/

small but import addition for all mac users:
- a097dd50d22c20098915074f375f0bae820a7dd8 adding the hidden MacOS file `.DS_Store` to the `.gitignore`