### PR TITLE
Fix use of gaussian_probe() + typo

### DIFF
--- a/src/cdtools/models/fancy_ptycho.py
+++ b/src/cdtools/models/fancy_ptycho.py
@@ -195,7 +195,7 @@ class FancyPtycho(CDIModel):
     @classmethod
     def from_dataset(cls,
                      dataset,
-                     probe_size=None,
+                     probe_shape=None,
                      randomize_ang=0,
                      n_modes=1,
                      n_obj_modes=1,
@@ -277,7 +277,7 @@ class FancyPtycho(CDIModel):
         )
 
         # Finally, initialize the probe and  object using this information
-        if probe_size is None:
+        if probe_shape is None:
             probe = tools.initializers.SHARP_style_probe(
                 dataset,
                 propagation_distance=propagation_distance,
@@ -288,7 +288,6 @@ class FancyPtycho(CDIModel):
                 dataset,
                 obj_basis,
                 probe_shape,
-                probe_size,
                 propagation_distance=propagation_distance,
             )
 

--- a/src/cdtools/models/multislice_ptycho.py
+++ b/src/cdtools/models/multislice_ptycho.py
@@ -181,7 +181,7 @@ class MultislicePtycho(CDIModel):
                      dataset,
                      dz,
                      nz,
-                     probe_size=None,
+                     probe_shape=None,
                      randomize_ang=0,
                      n_modes=1,
                      n_obj_modes=1,
@@ -262,7 +262,7 @@ class MultislicePtycho(CDIModel):
         )
 
         # Finally, initialize the probe and  object using this information
-        if probe_size is None:
+        if probe_shape is None:
             probe = tools.initializers.SHARP_style_probe(
                 dataset,
                 propagation_distance=propagation_distance,
@@ -273,7 +273,6 @@ class MultislicePtycho(CDIModel):
                 dataset,
                 obj_basis,
                 probe_shape,
-                probe_size,
                 propagation_distance=propagation_distance,
             )
 

--- a/src/cdtools/tools/initializers/initializers.py
+++ b/src/cdtools/tools/initializers/initializers.py
@@ -234,7 +234,7 @@ def gaussian_probe(dataset, basis, shape, sigma, propagation_distance=0, polariz
         polarizer = dataset.polarizer.tolist()
         analyzer = dataset.analyzer.tolist()
         factors = [(math.cos(math.radians(polarizer[idx] - analyzer[idx])))**2 for idx in range(len(dataset)) if (abs(polarizer[idx] - analyzer[idx]) > 5)]
-        avg_intensities = [t.sum(dataset[idx][1]) / factor[idx] for idx in range(len(dataset))]
+        avg_intensities = [t.sum(dataset[idx][1]) / factors[idx] for idx in range(len(dataset))]
 
     avg_intensity = t.mean(t.tensor(avg_intensities))
     probe_intensity = t.sum(t.abs(probe)**2)


### PR DESCRIPTION
my linter picked these up:

- f8bebd0436aeb468a2168fc6af9a6e079f52fa59 fixed typo from `factor` to `factors`
- efadaf807e769a39bb264bb306cec672e5180635 [`gaussian_probe()`](https://github.com/cdtools-developers/cdtools/blob/db2450c5aeb5a929694f903c900490552befd482/src/cdtools/tools/initializers/initializers.py#L168) takes only the `shape` as an input, from what I understood is that `probe_shape` and `probe_size` are used in the same way here, so it was changed to `probe_shape` and an additional `probe_size` was removed


