### PR TITLE
[fix] remove environment from github actions for docs deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,10 +43,6 @@ jobs:
       group: "pages"
       cancel-in-progress: false
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This should fix the doc deployment without adding a github environment from PR #21. Also see discussion in #20. 