### PR TITLE
[minor doc fix] update links to automatic docs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,7 @@ identifiers:
     value: 'https://github.com/cdtools-developers/cdtools'
     description: Github Repository
 repository-code: 'https://github.com/cdtools-developers/cdtools'
-url: 'https://cdtools-developers.github.io/cdtools-docs/'
+url: 'https://cdtools-developers.github.io/cdtools/'
 abstract: >-
   CDTools is a python library for ptychography and CDI
   reconstructions, using an Automatic Differentiation based

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ model.compare(dataset) # See how the simulated and measured patterns compare
 plt.show()
 ```
 
-Full installation instructions and documentation can be found [here](https://cdtools-developers.github.io/cdtools-docs/).
+Full installation instructions and documentation can be found [here](https://cdtools-developers.github.io/cdtools/).
 
 
 CDTools was developed in the [photon scattering lab](https://scattering.mit.edu/) at MIT, and further development took place within the [computational x-ray imaging group](https://www.psi.ch/en/cxi) at PSI. The code is distributed under an MIT (a.k.a. Expat) license. If you would like to publish any work that uses CDTools, please contact [Abe Levitan](mailto:abraham.levitan@psi.ch).


### PR DESCRIPTION
This PR update the links to the docs from `https://cdtools-developers.github.io/cdtools-docs/` to the automatic docs `https://cdtools-developers.github.io/cdtools/` in the `readme` and `citation` files.