### PR TITLE
Fix an issue for datasets with colinear translations

### DIFF
--- a/src/cdtools/datasets/ptycho_2d_dataset.py
+++ b/src/cdtools/datasets/ptycho_2d_dataset.py
@@ -269,8 +269,11 @@ class Ptycho2DDataset(CDataset):
         """Plots the mean diffraction pattern across the dataset
 
         The output is normalized so that the summed intensity on the
-        detector is equal to the total intensity of light that passed
+        detector is roughly equal to the total intensity of light that passed
         through the sample within each detector conjugate field of view.
+
+        If the scan points are colinear (which causes issues for this
+        estimation), the mean pattern is displayed unscaled.
 
         The plot is plotted as log base 10 of the output plus log_offset.
         By default, log_offset is set equal to 1, which is a good level for


### PR DESCRIPTION
There was an issue in the calculation of the scaling for the scaled mean diffraction pattern, which would cause a crash whenever dataset.inspect() was called on a dataset with fully colinear scan points. A special case of this which happens a lot is when there is no scanning, or all the scan points are equal in the dataset.

I updated the functions to revert to just displaying the mean pattern in this case, and raising a warning. I also updated the docstrings. I did not add any tests because coverage for the dataset classes is quite sparse and feels like a separate project.

To test this specifically, one can run a modified version of `inspect_dataset.py` from the examples:

```python
import cdtools
from matplotlib import pyplot as plt

# First, we load an example dataset from a .cxi file
filename = 'example_data/AuBalls_700ms_30nmStep_3_6SS_filter.cxi'
dataset = cdtools.datasets.Ptycho2DDataset.from_cxi(filename)

dataset.translations[:] = 0

# And we take a look at the data
dataset.inspect()
plt.show()
```