### PR TITLE
Add the ability for fancy_ptycho to model detectors with spatially varying quantum efficiency

### DIFF
--- a/src/cdtools/datasets/base.py
+++ b/src/cdtools/datasets/base.py
@@ -110,6 +110,8 @@ class CDataset(torchdata.Dataset):
 
         if self.mask is not None:
             self.mask = self.mask.to(*args,**mask_kwargs)
+        if self.qe_mask is not None:
+            self.qe_mask = self.qe_mask.to(*args,**kwargs)
         if self.background is not None:
             self.background = self.background.to(*args,**kwargs)
 
@@ -205,12 +207,17 @@ class CDataset(torchdata.Dataset):
                              'basis'    : basis,
                              'corner'   : corner}
         mask = cdtdata.get_mask(cxi_file)
+        qe_mask = cdtdata.get_qe_mask(cxi_file)
         dark = cdtdata.get_dark(cxi_file)
-        return cls(entry_info = entry_info,
-                   sample_info = sample_info,
-                   wavelength=wavelength,
-                   detector_geometry=detector_geometry,
-                   mask=mask, background=dark)
+        return cls(
+            entry_info=entry_info,
+            sample_info=sample_info,
+            wavelength=wavelength,
+            detector_geometry=detector_geometry,
+            mask=mask,
+            qe_mask=qe_mask,
+            background=dark,
+        )
     
     
     def to_cxi(self, cxi_file):
@@ -248,6 +255,8 @@ class CDataset(torchdata.Dataset):
                                corner = corner)
         if self.mask is not None:
             cdtdata.add_mask(cxi_file, self.mask)
+        if self.qe_mask is not None:
+            cdtdata.add_qe_mask(cxi_file, self.qe_mask)
         if self.background is not None:
             cdtdata.add_dark(cxi_file, self.background)
         

--- a/src/cdtools/datasets/base.py
+++ b/src/cdtools/datasets/base.py
@@ -34,10 +34,16 @@ class CDataset(torchdata.Dataset):
     needed to allow for easy mixing of data on the CPU and GPU.
     """
 
-    def __init__(self, entry_info=None, sample_info=None,
-                 wavelength=None,
-                 detector_geometry=None, mask=None,
-                 background=None):
+    def __init__(
+            self,
+            entry_info=None,
+            sample_info=None,
+            wavelength=None,
+            detector_geometry=None,
+            mask=None,
+            qe_mask=None,
+            background=None,
+    ):
 
         """The __init__ function allows construction from python objects.
 
@@ -73,6 +79,12 @@ class CDataset(torchdata.Dataset):
             self.mask = t.tensor(mask, dtype=t.bool)
         else:
             self.mask = None
+
+        if qe_mask is not None:
+            self.qe_mask = t.as_tensor(qe_mask, dtype=t.float32)
+        else:
+            self.qe_mask = None
+
         if background is not None:
             self.background = t.tensor(background, dtype=t.float32)
         else:

--- a/src/cdtools/datasets/ptycho_2d_dataset.py
+++ b/src/cdtools/datasets/ptycho_2d_dataset.py
@@ -270,8 +270,11 @@ class Ptycho2DDataset(CDataset):
         """Plots the mean diffraction pattern across the dataset
 
         The output is normalized so that the summed intensity on the
-        detector is equal to the total intensity of light that passed
+        detector is roughly equal to the total intensity of light that passed
         through the sample within each detector conjugate field of view.
+
+        If the scan points are colinear (which causes issues for this
+        estimation), the mean pattern is displayed unscaled.
 
         The plot is plotted as log base 10 of the output plus log_offset.
         By default, log_offset is set equal to 1, which is a good level for

--- a/src/cdtools/datasets/ptycho_2d_dataset.py
+++ b/src/cdtools/datasets/ptycho_2d_dataset.py
@@ -380,7 +380,7 @@ class Ptycho2DDataset(CDataset):
         the dataset is downsampled with the data. The background is downsampled
         using the same method as the data.
 
-        If there is no quantum efficiency mask, then the mask is downsapled so
+        If there is no quantum efficiency mask, then the mask is downsampled so
         that any output pixel containing a masked pixel will be masked. If there
         is a quantum efficiency mask, then the quantum efficiency mask is
         downsampled using the same method as the data, and the mask is

--- a/src/cdtools/datasets/ptycho_2d_dataset.py
+++ b/src/cdtools/datasets/ptycho_2d_dataset.py
@@ -77,6 +77,7 @@ class Ptycho2DDataset(CDataset):
             self.intensities = t.as_tensor(intensities, dtype=t.float32)
         else:
             self.intensities = None
+
             
     def __len__(self):
         return self.patterns.shape[0]
@@ -372,10 +373,19 @@ class Ptycho2DDataset(CDataset):
         equal to the sum of a <factor> x <factor> region of pixels in the
         input pattern. This summation is done by pytorch.functional.avg_pool2d.
         
-        Any mask and background data which is stored with the dataset is
-        downsampled with the data. The background is downsampled using the same
-        method as the data. The mask is expanded so that any output pixel
-        containing a masked pixel will be masked.
+        Any mask, quantum efficiency, and background data which is stored with
+        the dataset is downsampled with the data. The background is downsampled
+        using the same method as the data.
+
+        If there is no quantum efficiency mask, then the mask is downsapled so
+        that any output pixel containing a masked pixel will be masked. If there
+        is a quantum efficiency mask, then the quantum efficiency mask is
+        downsampled using the same method as the data, and the mask is
+        downsampled to include any pixels for which there is at least one valid
+        pixel.
+
+        To avoid leakage of data from masked pixels, the data is first
+        multiplied by the mask before downsampling.
         
         Parameters
         ----------
@@ -383,17 +393,41 @@ class Ptycho2DDataset(CDataset):
             Default 2, the factor to downsample by
 
         """
-        self.patterns = t.nn.functional.avg_pool2d(
-            self.patterns.unsqueeze(0), factor, divisor_override=1)[0]
-        self.mask = t.logical_not(t.nn.functional.max_pool2d(
-            (1-self.mask.to(dtype=t.uint8)).unsqueeze(0).unsqueeze(0),
-            factor
-        )[0,0].to(dtype=t.bool))
+        if hasattr(self, 'mask') and self.mask is not None:
+            self.patterns = t.nn.functional.avg_pool2d(
+                (self.mask * self.patterns).unsqueeze(0),
+                factor, divisor_override=1)[0]
+        else:
+            self.patterns = t.nn.functional.avg_pool2d(
+                self.patterns.unsqueeze(0),
+                factor, divisor_override=1)[0]
+            
+
+        # If we have a QE mask, we want to include all pixels for which at
+        # least one of the input pixels was unmasked, because we can account
+        # for the masked pixels through quantum efficiency
+        if hasattr(self, 'qe_mask') and self.qe_mask is not None:
+            self.qe_mask = t.nn.functional.avg_pool2d(
+                (self.mask * self.qe_mask).unsqueeze(0).unsqueeze(0),
+                factor)[0,0]
+            self.mask = t.nn.functional.max_pool2d(
+                self.mask.to(dtype=t.uint8).unsqueeze(0).unsqueeze(0),
+                factor)[0,0].to(dtype=t.bool)
+            
+        # But if there is no QE mask, we need to only preserve pixels for
+        # which all input pixels were unmasked
+        elif hasattr(self, 'mask') and self.mask is not None:
+            self.mask = t.logical_not(t.nn.functional.max_pool2d(
+                (1-self.mask.to(dtype=t.uint8)).unsqueeze(0).unsqueeze(0),
+                factor
+            )[0,0].to(dtype=t.bool))
         
         self.detector_geometry['basis'] = \
             self.detector_geometry['basis'] * factor
 
-        if self.background is not None:
+
+        
+        if hasattr(self, 'background') and self.background is not None:
             self.background = t.nn.functional.avg_pool2d(
                 self.background.unsqueeze(0).unsqueeze(0),
                 factor,

--- a/src/cdtools/models/fancy_ptycho.py
+++ b/src/cdtools/models/fancy_ptycho.py
@@ -28,6 +28,7 @@ class FancyPtycho(CDIModel):
                  probe_fourier_shifts=None,
                  mask=None,
                  weights=None,
+                 qe_mask=None,
                  translation_scale=1,
                  saturation=None,
                  probe_support=None,
@@ -87,7 +88,14 @@ class FancyPtycho(CDIModel):
         else:
             self.register_buffer('mask',
                                  t.as_tensor(mask, dtype=t.bool))
-        
+
+
+        if qe_mask is None:
+            self.qe_mask = None
+        else:
+            self.qe_mask = t.nn.Parameter(
+                t.as_tensor(qe_mask, dtype=dtype))
+            
         probe_guess = t.as_tensor(probe_guess, dtype=t.complex64)
         obj_guess = t.as_tensor(obj_guess, dtype=t.complex64)
 
@@ -202,6 +210,7 @@ class FancyPtycho(CDIModel):
                      dm_rank=None,
                      translation_scale=1,
                      saturation=None,
+                     use_qe_mask=False,
                      probe_support_radius=None,
                      probe_fourier_crop=None,
                      propagation_distance=None,
@@ -376,6 +385,11 @@ class FancyPtycho(CDIModel):
         else:
             mask = None
 
+        if use_qe_mask:
+            qe_mask = t.ones(mask.shape, dtype=t.float32)
+        else:
+            qe_mask = None
+            
         if probe_support_radius is not None:
             probe_support = t.zeros(probe[0].shape, dtype=t.bool)
             xs, ys = np.mgrid[:probe.shape[-2], :probe.shape[-1]]
@@ -389,24 +403,34 @@ class FancyPtycho(CDIModel):
         else:
             probe_support = None
 
-        return cls(wavelength, det_geo, obj_basis, probe, obj,
-                   surface_normal=surface_normal,
-                   min_translation=min_translation,
-                   translation_offsets=translation_offsets,
-                   weights=Ws, mask=mask, background=background,
-                   translation_scale=translation_scale,
-                   saturation=saturation,
-                   probe_basis=probe_basis,
-                   probe_support=probe_support,
-                   fourier_probe=fourier_probe,
-                   oversampling=oversampling,
-                   loss=loss, units=units,
-                   probe_fourier_shifts=probe_fourier_shifts,
-                   simulate_probe_translation=simulate_probe_translation,
-                   simulate_finite_pixels=simulate_finite_pixels,
-                   phase_only=phase_only,
-                   exponentiate_obj=exponentiate_obj,
-                   obj_view_crop=obj_view_crop)
+        return cls(
+            wavelength,
+            det_geo,
+            obj_basis,
+            probe,
+            obj,
+            surface_normal=surface_normal,
+            min_translation=min_translation,
+            translation_offsets=translation_offsets,
+            weights=Ws,
+            mask=mask,
+            background=background,
+            qe_mask=qe_mask,
+            translation_scale=translation_scale,
+            saturation=saturation,
+            probe_basis=probe_basis,
+            probe_support=probe_support,
+            fourier_probe=fourier_probe,
+            oversampling=oversampling,
+            loss=loss,
+            units=units,
+            probe_fourier_shifts=probe_fourier_shifts,
+            simulate_probe_translation=simulate_probe_translation,
+            simulate_finite_pixels=simulate_finite_pixels,
+            phase_only=phase_only,
+            exponentiate_obj=exponentiate_obj,
+            obj_view_crop=obj_view_crop
+        )
 
 
     def interaction(self, index, translations, *args):
@@ -521,6 +545,7 @@ class FancyPtycho(CDIModel):
             wavefields,
             self.background,
             measurement=tools.measurements.incoherent_sum,
+            qe_mask=self.qe_mask,
             saturation=self.saturation,
             oversampling=self.oversampling,
             simulate_finite_pixels=self.simulate_finite_pixels,
@@ -840,7 +865,10 @@ class FancyPtycho(CDIModel):
         ('Corrected Translations',
          lambda self, fig, dataset: p.plot_translations(self.corrected_translations(dataset), fig=fig, units=self.units)),
         ('Background',
-         lambda self, fig: p.plot_amplitude(self.background**2, fig=fig))
+         lambda self, fig: p.plot_amplitude(self.background**2, fig=fig)),
+        ('Quantum Efficiency Mask',
+         lambda self, fig: p.plot_amplitude(self.qe_mask, fig=fig),
+         lambda self: (hasattr(self, 'qe_mask') and self.qe_mask is not None))
     ]
     
     

--- a/src/cdtools/models/fancy_ptycho.py
+++ b/src/cdtools/models/fancy_ptycho.py
@@ -95,6 +95,10 @@ class FancyPtycho(CDIModel):
         else:
             self.qe_mask = t.nn.Parameter(
                 t.as_tensor(qe_mask, dtype=dtype))
+            # I want the ability to optimize over this, but experience shows
+            # that it is wildly unstable, so I think it's best to keep
+            # gradients turned off by default
+            self.qe_mask.requires_grad=False
             
         probe_guess = t.as_tensor(probe_guess, dtype=t.complex64)
         obj_guess = t.as_tensor(obj_guess, dtype=t.complex64)
@@ -386,7 +390,10 @@ class FancyPtycho(CDIModel):
             mask = None
 
         if use_qe_mask:
-            qe_mask = t.ones(mask.shape, dtype=t.float32)
+            if hasattr(dataset, 'qe_mask') and dataset.qe_mask is not None:
+                qe_mask = t.as_tensor(dataset.qe_mask, dtype=t.float32)
+            else:
+                qe_mask = t.ones(dataset.patterns.shape[-2:], dtype=t.float32)
         else:
             qe_mask = None
             

--- a/src/cdtools/tools/measurements/measurements.py
+++ b/src/cdtools/tools/measurements/measurements.py
@@ -196,22 +196,15 @@ def quadratic_background(
     sim_patterns : torch.Tensor
         A real MxN array storing the wavefield's intensities
     """
-
-    if detector_slice is None:
-        raw_intensity = measurement(
-            wavefield,
-            *args,
-            epsilon=epsilon,
-            oversampling=oversampling,
-            simulate_finite_pixels=simulate_finite_pixels)
-    else:
-        raw_intensity = measurement(
-            wavefield,
-            *args,
-            detector_slice=detector_slice,
-            epsilon=epsilon,
-            oversampling=oversampling,
-            simulate_finite_pixels=simulate_finite_pixels)
+    
+    raw_intensity = measurement(
+        wavefield,
+        *args,
+        detector_slice=detector_slice,
+        epsilon=epsilon,
+        oversampling=oversampling,
+        simulate_finite_pixels=simulate_finite_pixels
+    )
 
     if qe_mask is None:
         output = raw_intensity + background**2

--- a/src/cdtools/tools/measurements/measurements.py
+++ b/src/cdtools/tools/measurements/measurements.py
@@ -155,7 +155,18 @@ def incoherent_sum(wavefields, detector_slice=None, epsilon=1e-7, saturation=Non
         return t.clamp(output + epsilon,0,saturation)
 
 
-def quadratic_background(wavefield, background, *args, detector_slice=None, measurement=intensity, epsilon=1e-7, saturation=None, oversampling=1, simulate_finite_pixels=False):
+def quadratic_background(
+        wavefield,
+        background,
+        *args,
+        detector_slice=None,
+        measurement=intensity,
+        epsilon=1e-7,
+        qe_mask=None,
+        saturation=None,
+        oversampling=1,
+        simulate_finite_pixels=False
+):
     """Returns the intensity of a wavefield plus a background
     
     The intensity is calculated via the given measurment function 
@@ -173,6 +184,8 @@ def quadratic_background(wavefield, background, *args, detector_slice=None, meas
         Optional, a slice or tuple of slices defining a section of the simulation to return
     measurement : function
         Default is measurements.intensity, the measurement function to use.
+    qe_mask : torch.Tensor
+        A tensor storing the per-pixel quantum efficiency (up to an unknown global scaling factor)
     saturation : float
         Optional, a maximum saturation value to clamp the resulting intensities to
     oversampling : int
@@ -183,18 +196,28 @@ def quadratic_background(wavefield, background, *args, detector_slice=None, meas
     sim_patterns : torch.Tensor
         A real MxN array storing the wavefield's intensities
     """
-    
-    if detector_slice is None:
-        output = measurement(wavefield, *args, epsilon=epsilon,
-                             oversampling=oversampling,
-                             simulate_finite_pixels=simulate_finite_pixels) \
-                             + background**2
-    else:
-        output = measurement(wavefield, *args, detector_slice=detector_slice,
-                             epsilon=epsilon, oversampling=oversampling,
-                             simulate_finite_pixels=simulate_finite_pixels) \
-                            + background**2
 
+    if detector_slice is None:
+        raw_intensity = measurement(
+            wavefield,
+            *args,
+            epsilon=epsilon,
+            oversampling=oversampling,
+            simulate_finite_pixels=simulate_finite_pixels)
+    else:
+        raw_intensity = measurement(
+            wavefield,
+            *args,
+            detector_slice=detector_slice,
+            epsilon=epsilon,
+            oversampling=oversampling,
+            simulate_finite_pixels=simulate_finite_pixels)
+
+    if qe_mask is None:
+        output = raw_intensity + background**2
+    else:
+        output = (qe_mask * raw_intensity) + background**2
+        
     # This has to be done after the background is added, hence we replicate
     # it here
     if saturation is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,9 +137,16 @@ def ptycho_cxi_1():
     # Remember the format for the CXI file differs from the format used
     # internally
     mask = np.zeros((256,256)).astype(np.int32)
+    mask[5,8] = 1
     expected['mask'] = np.ones((256,256)).astype(bool)
+    expected['mask'][5,8] = 0
     d1f.create_dataset('mask',data=mask)
 
+    # There is no specification for this in the CXI file format :(
+    qe_mask = np.ones((256,256)).astype(np.float32)
+    expected['qe_mask'] = qe_mask
+    d1f.create_dataset('qe_mask',data=qe_mask)
+    
     # Create an initial background
     dark = np.ones((256,256)) * 0.01
     expected['dark'] = dark
@@ -228,6 +235,8 @@ def ptycho_cxi_2():
     # internally
     expected['mask'] = None
 
+    expected['qe_mask'] = None
+    
     # Test with a set of dark images
     dark = np.ones((10,256,256)) * 0.01
     expected['dark'] = np.nanmean(dark,axis=0)
@@ -305,8 +314,13 @@ def ptycho_cxi_3():
     # Remember the format for the CXI file differs from the format used
     # internally
     mask = np.ones((256,256)).astype(np.uint32) * 0x00001000
+    mask[15,47] = 38
     expected['mask'] = np.ones((256,256)).astype(bool)
+    expected['mask'][15,47] = 0
     d1f.create_dataset('mask',data=mask)
+
+    expected['qe_mask'] = None
+    
     expected['dark'] = None
     
     data1f = e1f.create_group('data_1')

--- a/tests/models/test_fancy_ptycho.py
+++ b/tests/models/test_fancy_ptycho.py
@@ -21,6 +21,7 @@ def test_lab_ptycho(lab_ptycho_cxi, reconstruction_device, show_plot):
         propagation_distance=5e-3, 
         units='mm', 
         obj_view_crop=-50,
+        use_qe_mask=True, # test this in the case where no qe mask is defined
     )
     
     print('Running reconstruction on provided reconstruction_device,',
@@ -28,7 +29,7 @@ def test_lab_ptycho(lab_ptycho_cxi, reconstruction_device, show_plot):
     model.to(device=reconstruction_device)
     dataset.get_as(device=reconstruction_device)
 
-    for loss in model.Adam_optimize(50, dataset, lr=0.02, batch_size=10):
+    for loss in model.Adam_optimize(70, dataset, lr=0.02, batch_size=10):
         print(model.report())
         if show_plot and model.epoch % 10 == 0:
             model.inspect(dataset)

--- a/tests/tools/test_analysis.py
+++ b/tests/tools/test_analysis.py
@@ -160,7 +160,7 @@ def test_standardize():
     probe = probe * np.exp(-1j * np.angle(np.sum(probe)))
 
     assert np.isclose(1, np.sum(np.abs(probe)**2)/ len(probe.ravel()))
-    assert np.angle(np.sum(probe)) < 1e-7
+    assert np.angle(np.sum(probe)) < 2e-7
 
     obj = 30 * np.random.rand(230,240) * np.exp(1j * (np.random.rand(230,240) - 0.5))
     obj_slice = np.s_[(obj.shape[0]//8)*3:(obj.shape[0]//8)*5,
@@ -232,7 +232,7 @@ def test_synthesize_reconstructions():
     probe = probe * np.exp(-1j * np.angle(np.sum(probe)))
 
     assert np.isclose(1, np.sum(np.abs(probe)**2)/ len(probe.ravel()))
-    assert np.abs(np.angle(np.sum(probe))) < 1e-7
+    assert np.abs(np.angle(np.sum(probe))) < 2e-7
 
     obj = 30 * np.random.rand(230,240) * np.exp(1j * (np.random.rand(230,240) - 0.5))
     obj_slice = np.s_[(obj.shape[0]//8)*3:(obj.shape[0]//8)*5,

--- a/tests/tools/test_data.py
+++ b/tests/tools/test_data.py
@@ -60,7 +60,15 @@ def test_get_mask(test_ptycho_cxis):
         mask = data.get_mask(cxi)
         if expected['mask'] is None and mask is None:
             continue
-        assert np.all(data.get_mask(cxi) == expected['mask'])
+        assert np.all(mask == expected['mask'])
+
+        
+def test_get_qe_mask(test_ptycho_cxis):
+    for cxi, expected in test_ptycho_cxis:
+        qe_mask = data.get_qe_mask(cxi)
+        if expected['qe_mask'] is None and qe_mask is None:
+            continue
+        assert np.allclose(qe_mask, expected['qe_mask'])
 
 
 def test_get_dark(test_ptycho_cxis):
@@ -205,6 +213,18 @@ def test_add_mask(tmp_path):
         read_mask = data.get_mask(f)
 
     assert np.all(mask == read_mask)
+
+    
+def test_add_qe_mask(tmp_path):
+    qe_mask = np.random.rand(350,199).astype(np.float32)
+
+    with data.create_cxi(tmp_path / 'test_add_qe_mask.cxi') as f:
+        data.add_qe_mask(f, qe_mask)
+
+    with h5py.File(tmp_path / 'test_add_qe_mask.cxi','r') as f:
+        read_qe_mask = data.get_qe_mask(f)
+
+    assert np.allclose(qe_mask, read_qe_mask)
 
     
 def test_add_dark(tmp_path):


### PR DESCRIPTION
Recently I wound up working with a lot of data from detectors which have very... not flat flat fields. In the past I've seen this corrected by dividing out the flat-field, but this messes with the photon statistics a bit, and is especially bad for photon-counting data where suddenly you need to store integer-valued data as floating-point.

I think the right way to solve this is to introduce a layer into the forward model to simulate the variable detector quantum efficiency. So, in this PR I added that to fancy_ptycho. This comes along with:

* CDataset and subclasses like Ptycho2DDataset can now load and save a "quantum efficienct mask" qe_mask, basically a flat-field measurement. This isn't defined in the official cxi file format, but I think it was worth creating a way to do it because you'd want to be able to easily pass this around with the data
* When initializing FancyPtycho using from_dataset, now there is a new argument "use_qe_mask", which is set to "False" by default to preserve the original behavior. If set to "true", it will either load the quantum efficiency mask from the dataset, or (if no qe_mask is available) initialize the mask with ones.
* The qe_mask is defined as a torch.nn.Parameter, which (by default) has requires_grad set to False. I chose this because I could imagine there being value in refining the quantum efficiency mask in some cases, although some preliminary tests indicate that in general it's quite unstable to do. But, defining it as a parameter now makes it easy to test this in individual cases

I added a bit of test coverage, including using this model (with a qe_mask identically equal to 1) in one of the slow fancy_ptycho tests. I've also done a bit of testing with some datasets which are, unfortunately, not public.

I think it's possible that some bugs remain in the implementation of the qe_mask which might be surfaced later, although I've tried to test it rigorously. But I'd suggest that this can be ready to fold into master once we're confident that it isn't affecting any existing code that doesn't use this correction.

Let me know what you think!