### PR TITLE
[Bugfix] model.compare(dataset) does not work for the RPI test script

### DIFF
--- a/src/cdtools/models/base.py
+++ b/src/cdtools/models/base.py
@@ -872,7 +872,13 @@ class CDIModel(t.nn.Module):
             updating = True if len(axes[0].images) >= 1 else False
 
             inputs, output = dataset[idx:idx+1]
-            sim_data = self.forward(*inputs).detach().cpu().numpy()[0]
+            sim_data = self.forward(*inputs).detach().cpu().numpy()
+            # The length of sim_data.shape changes when you're doing 
+            # either a ptycho (3) or an RPI (2) reconstruction.
+            # We need to make sure that sim_data is 2D.
+            if len(sim_data.shape) > 2:
+                sim_data = sim_data[0]
+
             meas_data = output.detach().cpu().numpy()[0]
             if hasattr(self, 'mask') and self.mask is not None:
                 mask = self.mask.detach().cpu().numpy()


### PR DESCRIPTION
When running the transmission_RPI.py example script, an error is raised when calling `model.compare(dataset)`; see failure log at the end. This bug seems to originate from the shape of `sim_data` in the following line 
https://github.com/cdtools-developers/cdtools/blob/b3a70ec325c4493feffad13dd26aa0f60909bb91/src/cdtools/models/base.py#L875

Specifically, in the case of a FancyPtycho (and presumably other ptychography) model, the shape of `sim_data` will be (N, M). However, if an RPI model is used, the shape of `sim_data` becomes (N,), which causes an invalid shape error to get thrown when plotting an image.

The bugfix solves this issue by only adding the `[0]` whenever the shape of the `sim_data` is bigger than 2 dimensions.

## Failure log
```
cdtools/src/cdtools/models/base.py:922: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.slider = Slider(axslider, 'Pattern #', 0, len(dataset)-1, valstep=1, valfmt="%d")
Traceback (most recent call last):
  File "/homes/dayne/repositories/cdtools_yoshikisd/cdtools/examples/transmission_RPI.py", line 46, in <module>
    model.compare(dataset)
  File "/homes/dayne/repositories/cdtools_yoshikisd/cdtools/src/cdtools/models/base.py", line 940, in compare
    update(0)
  File "/homes/dayne/repositories/cdtools_yoshikisd/cdtools/src/cdtools/models/base.py", line 891, in update
    sim = axes[0].imshow(sim_data)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/homes/dayne/.conda/envs/cdtools_testing/lib/python3.12/site-packages/matplotlib/__init__.py", line 1473, in inner
    return func(
           ^^^^^
  File "/homes/dayne/.conda/envs/cdtools_testing/lib/python3.12/site-packages/matplotlib/axes/_axes.py", line 5895, in imshow
    im.set_data(X)
  File "/homes/dayne/.conda/envs/cdtools_testing/lib/python3.12/site-packages/matplotlib/image.py", line 729, in set_data
    self._A = self._normalize_image_array(A)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/homes/dayne/.conda/envs/cdtools_testing/lib/python3.12/site-packages/matplotlib/image.py", line 697, in _normalize_image_array
    raise TypeError(f"Invalid shape {A.shape} for image data")
TypeError: Invalid shape (1000,) for image data
```