### PR TITLE
Pin current codebase version to 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cdtools",
-    version="0.2.0",
+    version="0.3.0",
     python_requires='>3.8', # recommended minimum version for pytorch 2.3.0
     author="Abe Levitan",
     author_email="abraham.levitan@psi.ch",


### PR DESCRIPTION
This PR establishes version `0.3.0` as the current release for the project. Add release tag `v0.3.0`

This version tagging enables our release workflow and establishes a foundation for future version management. While the version number is somewhat arbitrary, creating this initial release point is essential for implementing proper release processes going forward.