### PR TITLE
Add pypi workflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cdtools",
-    version="0.3.1",
+    version="0.3.0",
     python_requires='>3.8', # recommended minimum version for pytorch 2.3.0
     author="Abe Levitan",
     author_email="abraham.levitan@psi.ch",


### PR DESCRIPTION
This PR includes a workflow for publishing to PyPi upon new github releases as discussed in #38. Instructions for `pip install` will be updated later, so it can be tested first. It can also considered later switching to more modern `pyproject.toml`. 