### PR TITLE
fix: change name from cdtools to cdtools-py to match pypi naming

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="cdtools",
+    name="cdtools-py",
     version="0.3.0",
     python_requires='>3.8', # recommended minimum version for pytorch 2.3.0
     author="Abe Levitan",


### PR DESCRIPTION
The issue is that the name `cdtools` cannot be chosen on pypi, which lead to problems during the automatic upload. The project name is on pypi is `cdtools-py`. 

**Changes:**
- Updated `setup.py` to use `cdtools-py` as the PyPI package name
- Import statements remain unchanged (`import cdtools` still works)


**Note:** Different PyPI and import names are common in Python packages, eg:
- `pip install Pillow` → `import PIL`
- `pip install beautifulsoup4` → `import bs4`
- `pip install PyYAML` → `import yaml`

relevant issues and PRs: #38 and #39 
