### PR TITLE
Set fixed RNG seed for reconstruction pytests

### DIFF
--- a/tests/models/test_fancy_ptycho.py
+++ b/tests/models/test_fancy_ptycho.py
@@ -5,6 +5,8 @@ import torch as t
 import cdtools
 from matplotlib import pyplot as plt
 
+# Force all reconstructions to use the same RNG seed
+t.manual_seed(0)
 
 def test_center_probe(lab_ptycho_cxi):
     dataset = cdtools.datasets.Ptycho2DDataset.from_cxi(lab_ptycho_cxi)

--- a/tests/models/test_simple_ptycho.py
+++ b/tests/models/test_simple_ptycho.py
@@ -1,6 +1,10 @@
 import pytest
 import cdtools
 from matplotlib import pyplot as plt
+import torch as t
+
+# Force all reconstructions to use the same RNG seed
+t.manual_seed(0)
 
 @pytest.mark.slow
 def test_simple_ptycho(lab_ptycho_cxi, reconstruction_device, show_plot):


### PR DESCRIPTION
When running `pytest --runslow`, `test_fancy_ptycho` randomly fails during the `test_lab_ptycho` and `test_gold_balls` tests. When running multiple iterations of the pytest, the final reconstructed losses sometimes exceed the threshold by up to 10% or so (at least for the few attempts I've performed). 

I suspect this inconsistent performance occurs because of different RNG seeds being used for each test. This PR fixes the RNG seed to 0 for reconstruction-based pytests.

Here are the results I've gotten after fixing the seeds:
in `test_fancy_ptycho.py`
- test_lab_ptycho: 9.90599e-04
- test_gold_balls: 9.91784e-05

in `test_simple_ptycho.py`
- test_simple_ptycho: 1.26921e-02

These results are the same after running the pytest twice.