### PR TITLE
Fix a high priority bug with the masking system which was introduced in the switch to reconstructors classes

### DIFF
--- a/src/cdtools/reconstructors/base.py
+++ b/src/cdtools/reconstructors/base.py
@@ -190,7 +190,7 @@ class Reconstructor:
                     sim_patterns = self.model.forward(*inp)
 
                     # Calculate the loss
-                    if hasattr(self, 'mask'):
+                    if hasattr(self.model, 'mask'):
                         loss = self.model.loss(pats,
                                                sim_patterns,
                                                mask=self.model.mask)

--- a/tests/models/test_fancy_ptycho.py
+++ b/tests/models/test_fancy_ptycho.py
@@ -52,6 +52,10 @@ def test_lab_ptycho(lab_ptycho_cxi, reconstruction_device, show_plot):
     print('\nTesting performance on the standard transmission ptycho dataset')
     dataset = cdtools.datasets.Ptycho2DDataset.from_cxi(lab_ptycho_cxi)
 
+    # Test the masking system
+    dataset.mask[110:115,65:70] = 0
+    dataset.patterns[...,~dataset.mask] = t.max(dataset.patterns)
+    
     model = cdtools.models.FancyPtycho.from_dataset(
         dataset,
         n_modes=3,


### PR DESCRIPTION
There was a typo in the reconstructors class which broke the masking system. I noticed it today while working on a separate project.

I believe this change fixes it, and in addition I:

* Checked the entire file for all uses of "self" in recconstructors/base.py and the subclasses to check if any similar bugs had slipped by the earlier round of review
* Added a few lines to test_fancy_ptycho which will cause that reconstruction to fail with an unacceptably large error if the masking system stops working. I prefer folding it into the same test, rather than making a separate test, to keep the number of slow tests down.
