### PR TITLE
Stop Ptycho2DDataset.inspec() from raising a divzero error in many situations

### DIFF
--- a/src/cdtools/datasets/ptycho_2d_dataset.py
+++ b/src/cdtools/datasets/ptycho_2d_dataset.py
@@ -220,7 +220,8 @@ class Ptycho2DDataset(CDataset):
             logarithmic=True,
             units='um',
             log_offset=1,
-            plot_mean_pattern=True
+            plot_mean_pattern=True,
+            plot_mask=False,
     ):
         """Launches an interactive plot for perusing the data
 
@@ -241,7 +242,7 @@ class Ptycho2DDataset(CDataset):
                 mask = 1
                 
             if logarithmic:
-                return np.log(meas_data + log_offset) / np.log(10) * mask
+                return np.log10((meas_data * mask) + log_offset)
             else:
                 return meas_data * mask
 
@@ -268,6 +269,9 @@ class Ptycho2DDataset(CDataset):
 
         if plot_mean_pattern:
             self.plot_mean_pattern(log_offset=log_offset)
+
+        if plot_mask:
+            plotting.plot_real(self.mask, title='Dataset Mask')
             
         return plotting.plot_nanomap_with_images(self.translations.detach().cpu(), get_images, values=nanomap_values, nanomap_units=units, image_title='Diffraction Pattern', image_colorbar_title=cbar_title)
 


### PR DESCRIPTION
Because of how the calculation was done to display diffraction patterns in Ptycho2DDataset.inspect(), torch would often raise a divide by zero error if there were any *masked* pixels which were less than zero. This is pretty common e.g. on raw data from an Eiger detector.

I just tweaked the calculation so an error will only appear if unmasked pixels are below zero. I think in this case, it is appropriate for an error to pop up, as the user likely wants to be aware of such a situation.

This change also affects the output: now, masked pixels will always show as though they had a measured value of "0". Previously, they would always show the value "0", which only corresponds to the same thing when the log-offset is 1. I think this is more sane and consistent, but it does mean that in many situations it is no longer possible to determine which pixels are masked just by looking at dataset.inspect(). To account for this, I added an kwarg, `plot_mask`, which will plot the dataset's mask when set to True. I have it set to False by default to avoid cluttering the plots further.

Open to suggestions for tweaks, while I'm making changes here!