### PR TITLE
Add .readthedocs.yaml for ReadTheDocs hosting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
Enables versioned documentation on ReadTheDocs. Installs the package with its docs extras (sphinx, sphinx-rtd-theme, sphinx-argparse) so autodoc can import cdtools during the build.

This is related to #42 