### PR TITLE
Update the docs so it doesn't always think it's v0.2.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,19 +14,20 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath('../../src'))
+from cdtools._version import __version__
+
+# The full version, including alpha/beta/rc tags
+release = __version__
+# Displayed in the sidebar
+version = release
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'CDTools'
-copyright = '2019-2024, Abraham Levitan'
+project = f'CDTools (v{release})'
+copyright = '2019-2026, Abraham Levitan'
 author = 'Abraham Levitan'
-
-# The short X.Y version
-version = '0.2'
-# The full version, including alpha/beta/rc tags
-release = '0.2.0'
 
 
 # -- General configuration ---------------------------------------------------
@@ -90,6 +91,7 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+html_title = f'CDTools (v{release})'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Fixing some lingering issues with the docs which became apparent when starting to host multiple versions of the docs, related to #42 