### PR TITLE
Fix a high priority bug where reconstructions will crash upon saving

### DIFF
--- a/src/cdtools/models/base.py
+++ b/src/cdtools/models/base.py
@@ -192,7 +192,10 @@ class CDIModel(t.nn.Module):
             'loss_history': np.array(self.loss_history),
             'epoch': self.epoch,
             'training_history': self.training_history,
-            'loss_function': self.loss.__name__,
+            'loss_function': (
+                getattr(self.loss, '__name__', None) or 
+                getattr(self.loss.func, '__name__', str(self.loss))
+            ),
         }
 
 

--- a/tests/models/test_fancy_ptycho.py
+++ b/tests/models/test_fancy_ptycho.py
@@ -123,6 +123,9 @@ def test_lab_ptycho(lab_ptycho_cxi, reconstruction_device, show_plot):
         time.sleep(3)
         plt.close('all')
 
+    # Simply test that this does not fail
+    results = model.save_results(dataset)
+
     # If this fails, the reconstruction has gotten worse
     assert model.loss_history[-1] < 0.38
 

--- a/tests/models/test_simple_ptycho.py
+++ b/tests/models/test_simple_ptycho.py
@@ -29,5 +29,8 @@ def test_simple_ptycho(lab_ptycho_cxi, reconstruction_device, show_plot):
         time.sleep(3)
         plt.close('all')
 
+    # Simply test that this does not fail
+    results = model.save_results(dataset)
+
     # If this fails, the reconstruction got worse
     assert model.loss_history[-1] < 6.5


### PR DESCRIPTION
Also add test coverage to prevent a repeat. This bug was introduced in the newpoisson branch when "functools.partial" was used to wrap the default loss metrics. Must be merged to master ASAP.