### PR TITLE
bump the dev version to help referencing the latest batch of changes

### DIFF
--- a/src/cdtools/_version.py
+++ b/src/cdtools/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.2.dev"
+__version__ = "0.3.2.dev1"


### PR DESCRIPTION
There is some downstream code which relies on the latest batch of changes, so I'm bumping the version to 0.3.2.dev1 to help with referencing that, before we're ready for a full release